### PR TITLE
Invoicing zones 8a && 8b alphanumerical validation

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record10Description.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record10Description.kt
@@ -36,7 +36,7 @@ object Record10Description : RecordOrSegmentDescription() {
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "5,6a", "NumeroCompteFinancierAPartie1et2", "financialAccountNumber1", "N", pos, 12)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "6b", "Reserve", null, "N", pos, 4)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "7", "NumeroDeLenvoi", "sendingNumber", "N", pos, 3)
-        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a", "NumeroCompteFinancierB", "financialAccountNumber2", "N", pos, 12)
+        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a", "NumeroCompteFinancierB", "financialAccountNumber2", "A", pos, 12)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8b", "Reserve", null, "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "9", "CodeSuppressionFacturePapier", "deletionCodePaperInvoice", "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "10", "CodeFichierDeDecompte", null, "N", pos, 1)

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record20Description.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record20Description.kt
@@ -37,7 +37,7 @@ object Record20Description : RecordOrSegmentDescription() {
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "6a", "DateDeSortiePartie1", null, "N", pos, 4)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "6b", "DateDeSortiePartie2", null, "N", pos, 4)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "7", "NumeroMutualiteDaffiliation", null, "N", pos, 3)
-        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "IdentificationBeneficiairePartie1et2", null, "N", pos, 13)  //Forced to N so that it is padded with 0s
+        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "IdentificationBeneficiairePartie1et2", null, "A", pos, 13)  //Forced to A so that it is padded with blank spaces
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "9", "SexeBeneficiaire", null, "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "10", "TypeFacture", null, "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "11", "TypeDeFacturation", null, "N", pos, 1)

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record30Description.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record30Description.kt
@@ -37,7 +37,7 @@ object Record30Description : RecordOrSegmentDescription() {
             pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "5", "date premier jour facture", null, "N", pos, 8)
             pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "6a,6b", "date dernier jour facture (partie 1 et 2)", null, "N", pos, 8)
             pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "7", "numero mutualite d'affiliation", null, "N", pos, 3)
-            pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "identification beneficiaire (partie 1 et 2)", null, "N", pos, 13)  //Forced to N so that it is padded with 0s
+            pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "identification beneficiaire (partie 1 et 2)", null, "A", pos, 13)  //Forced to A so that it is padded with blank spaces
             pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "9", "sexe beneficiaire", null, "N", pos, 1)
             pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "10", "accouchement", null, "N", pos, 1)
             pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "11", "reference numero de compte financier", null, "N", pos, 1)

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record50Description.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record50Description.kt
@@ -37,7 +37,7 @@ object Record50Description : RecordOrSegmentDescription() {
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "5", "DatePremierePrestationEffectuee", null, "N", pos, 8)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "6a,6b", "DateDernierePrestationEffectueePartie1et2", null, "N", pos, 8)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "7", "NumeroMutualiteDaffiliation", null, "N", pos, 3)
-        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "IdentificationBeneficiairePartie1et2", null, "N", pos, 13)  //Forced to N so that it is padded with 0s
+        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "IdentificationBeneficiairePartie1et2", null, "A", pos, 13)  //Forced to A so that it is padded with blank spaces
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "9", "SexeBeneficiaire", "sex", "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "10", "Accouchement", null, "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "11", "ReferenceNumeroDeCompteFinancier", null, "N", pos, 1)

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record51Description.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record51Description.kt
@@ -37,7 +37,7 @@ object Record51Description : RecordOrSegmentDescription() {
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "6a", "reserve", null, "N", pos, 4)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "6b", "reserve", null, "N", pos, 4)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "7", "reserve", null, "N", pos, 3)
-        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "identification beneficiaire", "recipientIdentifier", "N", pos, 13)  //Forced to N so that it is padded with 0s
+        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "identification beneficiaire", "recipientIdentifier", "A", pos, 13)  //Forced to A so that it is padded with blank spaces
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "9", "reserve", null, "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "10", "reserve", null, "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "11", "reserve", null, "N", pos, 1)

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record52Description.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record52Description.kt
@@ -36,7 +36,7 @@ object Record52Description : RecordOrSegmentDescription() {
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "5", "Date de prestation", "prestationDate", "N", pos, 8)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "6a,6b", "Date de lecture document identite electronique (1 et 2)", "eidDate", "N", pos, 8)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "7", "reserve", null, "N", pos, 3)
-        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "Numero NISS du patient sauf en cas de convention internationale ou nouveaux-nes (1 et 2)", "patientINSS", "N", pos, 13)  //Forced to N so that it is padded with 0s
+        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "Numero NISS du patient sauf en cas de convention internationale ou nouveaux-nes (1 et 2)", "patientINSS", "A", pos, 13)  //Forced to A so that it is padded with blank spaces
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "9", "reserve", null, "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "10", "Type de support document identite electronique", "eidSupportType", "A", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "11", "Type de lecture document identite electronique", "eidReadingType", "A", pos, 1)

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record80Description.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record80Description.kt
@@ -36,7 +36,7 @@ object Record80Description : RecordOrSegmentDescription() {
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "5", "DateDadmission", null, "N", pos, 8)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "6a,6b", "DateDeSortiePartie1et2", null, "N", pos, 8)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "7", "NumeroMutualiteDaffiliation", null, "N", pos, 3)
-        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "IdentificationBeneficiairePartie1", "recipientIdentifier", "N", pos, 13)  //Forced to N so that it is padded with 0s
+        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a,8b", "IdentificationBeneficiairePartie1", "recipientIdentifier", "A", pos, 13)  //Forced to A so that it is padded with blank spaces
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "9", "SexeBeneficiaire", null, "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "10", "TypeFacture", null, "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "11", "Reserve", null, "N", pos, 1)

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record90Description.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Record90Description.kt
@@ -36,7 +36,7 @@ object Record90Description : RecordOrSegmentDescription() {
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "5,6a", "NumeroCompteFinancierAPartie1et2", "financialAccountNumber1", "N", pos, 12)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "6b", "Reserve", null, "N", pos, 4)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "7", "NumeroDenvoi", "sendingNumber", "N", pos, 3)
-        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a", "NumeroCompteFinancierB", "financialAccountNumber2", "N", pos, 12)
+        pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8a", "NumeroCompteFinancierB", "financialAccountNumber2", "A", pos, 12)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "8b", "Reserve", null, "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "9", "Reserve", null, "N", pos, 1)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "10", "Reserve", null, "N", pos, 1)


### PR DESCRIPTION
As per official documentation, zones 8a && 8b should be alphanumerical rather than numerical.